### PR TITLE
Support for GsonBuilder customization for JSON body serialization on Requests

### DIFF
--- a/src/main/java/com/rallydev/rest/request/CreateRequest.java
+++ b/src/main/java/com/rallydev/rest/request/CreateRequest.java
@@ -1,15 +1,12 @@
 package com.rallydev.rest.request;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.rallydev.rest.util.Fetch;
-import com.rallydev.rest.util.Ref;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -40,7 +37,7 @@ public class CreateRequest extends Request {
     public String getBody() {
         JsonObject wrapper = new JsonObject();
         wrapper.add(type, obj);
-        return new Gson().toJson(wrapper);
+        return gsonBuilder.create().toJson(wrapper);
     }
 
     /**

--- a/src/main/java/com/rallydev/rest/request/Request.java
+++ b/src/main/java/com/rallydev/rest/request/Request.java
@@ -1,5 +1,6 @@
 package com.rallydev.rest.request;
 
+import com.google.gson.GsonBuilder;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 
@@ -14,10 +15,16 @@ public abstract class Request {
     
     private List<NameValuePair> params = new ArrayList<NameValuePair>();
 
+	/**
+     * Gson Builder used for JSON serialization in this request.
+     */
+    protected GsonBuilder gsonBuilder;
+
     /**
      * Create a new request.
      */
     public Request() {
+        this.gsonBuilder = new GsonBuilder();
     }
 
     /**
@@ -46,6 +53,24 @@ public abstract class Request {
      */
     public void addParam(String name, String value) {
         getParams().add(new BasicNameValuePair(name, value));
+    }
+
+    /**
+     * Get the Gson Builder used for JSON serialization in this request.
+     *
+     * @return The Gson Builder used for JSON serialization
+     */
+    public GsonBuilder getGsonBuilder() {
+        return gsonBuilder;
+    }
+
+    /**
+     * Set the Gson Builder used for JSON serialization in this request.
+     *
+     * @param gsonBuilder The Gson Builder used for JSON serialization
+     */
+    public void setGsonBuilder(GsonBuilder gsonBuilder) {
+        this.gsonBuilder = gsonBuilder;
     }
 
     /**

--- a/src/main/java/com/rallydev/rest/request/UpdateRequest.java
+++ b/src/main/java/com/rallydev/rest/request/UpdateRequest.java
@@ -1,6 +1,5 @@
 package com.rallydev.rest.request;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.rallydev.rest.util.Fetch;
 import com.rallydev.rest.util.Ref;
@@ -39,7 +38,7 @@ public class UpdateRequest extends Request {
     public String getBody() {
         JsonObject wrapper = new JsonObject();
         wrapper.add(Ref.getTypeFromRef(ref), obj);
-        return new Gson().toJson(wrapper);
+        return gsonBuilder.create().toJson(wrapper);
     }
 
     /**

--- a/src/test/java/com/rallydev/rest/request/CreateRequestTest.java
+++ b/src/test/java/com/rallydev/rest/request/CreateRequestTest.java
@@ -1,5 +1,6 @@
 package com.rallydev.rest.request;
 
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.rallydev.rest.util.Fetch;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -14,6 +15,16 @@ public class CreateRequestTest {
         body.addProperty("Name", "My Story");
         CreateRequest req = new CreateRequest("HierarchicalRequirement", body);
         Assert.assertEquals(req.getBody(), "{\"HierarchicalRequirement\":{\"Name\":\"My Story\"}}");
+    }
+
+    @Test
+    public void shouldCreateACorrectBodyWithNullFields() {
+        JsonObject body = new JsonObject();
+        body.addProperty("Name", "My Story");
+        body.add("Feature", JsonNull.INSTANCE);
+        CreateRequest req = new CreateRequest("HierarchicalRequirement", body);
+        req.getGsonBuilder().serializeNulls();
+        Assert.assertEquals(req.getBody(), "{\"HierarchicalRequirement\":{\"Name\":\"My Story\",\"Feature\":null}}");
     }
 
     @Test

--- a/src/test/java/com/rallydev/rest/request/RequestTest.java
+++ b/src/test/java/com/rallydev/rest/request/RequestTest.java
@@ -1,5 +1,6 @@
 package com.rallydev.rest.request;
 
+import com.google.gson.GsonBuilder;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.testng.Assert;
@@ -44,5 +45,20 @@ public class RequestTest {
         r.setParams(params);
         Assert.assertSame(params, r.getParams());
         Assert.assertEquals(r.getParams().size(), 1);
+    }
+
+    @Test
+    public void shouldBeAbleToSetGsonBuilder() {
+        Request r = createRequest();
+        Assert.assertEquals(r.getParams().size(), 0);
+
+        GsonBuilder previous = r.getGsonBuilder();
+        GsonBuilder brandNew = new GsonBuilder();
+
+        r.setGsonBuilder(brandNew);
+
+        Assert.assertNotNull(r.getGsonBuilder());
+        Assert.assertSame(r.getGsonBuilder(), brandNew);
+        Assert.assertNotSame(brandNew, previous);
     }
 }

--- a/src/test/java/com/rallydev/rest/request/UpdateRequestTest.java
+++ b/src/test/java/com/rallydev/rest/request/UpdateRequestTest.java
@@ -1,5 +1,6 @@
 package com.rallydev.rest.request;
 
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.rallydev.rest.util.Fetch;
 import org.testng.Assert;
@@ -13,6 +14,16 @@ public class UpdateRequestTest {
         body.addProperty("Name", "My Story");
         UpdateRequest req = new UpdateRequest("https://rally1.rallydev.com/slm/webservice/1.32/hierarchicalrequirement/1234.js", body);
         Assert.assertEquals(req.getBody(), "{\"hierarchicalrequirement\":{\"Name\":\"My Story\"}}");
+    }
+
+    @Test
+    public void shouldCreateACorrectBodyWithNullFields() {
+        JsonObject body = new JsonObject();
+        body.addProperty("Name", "My Story");
+        body.add("Feature", JsonNull.INSTANCE);
+        UpdateRequest req = new UpdateRequest("https://rally1.rallydev.com/slm/webservice/1.32/hierarchicalrequirement/1234.js", body);
+        req.getGsonBuilder().serializeNulls();
+        Assert.assertEquals(req.getBody(), "{\"hierarchicalrequirement\":{\"Name\":\"My Story\",\"Feature\":null}}");
     }
 
     @Test


### PR DESCRIPTION
I've recently faced some issues when trying to set JSON fields values as Null on update requests, where these changes were not being reflected on Rally, and then opened a support case with Rally Support to confirm this behavior on the API (**Support Case #816821**).

We got this issue confirmed, and found out that the only way to have this behavior within the API for our application was with a workaround by extending/overwriting the **UpdateRequest** class, tweaking up a **GsonBuilder** prior to serializing our objects (enabling the null fields serialization), and confirmed that this mitigated the problem.

To have a full-scale solution on the API, I put together this Pull Request, which adds the ability to *set/customize a GsonBuilder* used for serialization on Requests, being now used on **CreateRequest#getBody()** and **UpdateRequest#getBody()**. I've shipped some test cases as well, to assert the functionality.