### PR TITLE
Exposing headers collection of Httplient for the client/consumer to add any extra headers

### DIFF
--- a/src/main/java/com/rallydev/rest/client/HttpClient.java
+++ b/src/main/java/com/rallydev/rest/client/HttpClient.java
@@ -244,4 +244,13 @@ public class HttpClient extends DefaultHttpClient
     public String getWsapiUrl() {
         return getServer() + "/slm/webservice/" + getWsapiVersion();
     }
+    
+    /**
+     * Get the Header map used for every Request. Which can be used to put any consumer/client specific headers in the Request 
+     * @return the header map of the Request
+     */
+    public Map<Header, String> getHeaders()
+    {
+      return headers;
+    }
 }


### PR DESCRIPTION
In PPM for Rally Integration we are using RallyrestToolkitForJava, as part of this we have a requirement to add headers in the Request to Rally as per one of our UserStory -US2285 - Support Rally Integration Headers that provides Rally statistics to track activity between CA PPM and Rally (OUT)

Here is the User Story Details given below

OBJECTIVE: **is to provide the ability to support Rally Integration Headers that provides Rally statistics to track activity between PPM and Rally**.

DESCRIPTION: Rally requires Technology Partners to provide some information about the integrations being used so that they can tailor the Web Services API to better suit customers' needs. This information does not include any proprietary or confidential data. The information requested is: 
1) Name : Integration Name such as "AGL Add-In"
2) Vendor: Integration Vendor -> Exact version of CA PPM as it is shown in the About dialog box. For example: CA PPM 14.3.0.298 07 25

3) Version: Integration Version -> This version is of the WSAPI version.

4) OS: Client Operating System Information such as "Linux2.6.18‐8.1.1.el5amd64"
5) Platform: Platform Information such as JDK version or Ruby runtime version such as  "Java, Sun Microsystems Inc. 1.5.0_11‐b03"
6) Library: Library Framework Information such as "RallyRubyRESTAPI" OR "ApacheAxis1.4"  

GETTING INTEGRATION INFORMATION via REST API:
For REST, Rally team requires that the above information is provided as the following HTTP headers:

**● X‐RallyIntegrationName ● X‐RallyIntegrationVendor ● X‐RallyIntegrationVersion ● X‐RallyIntegrationOS ● X‐RallyIntegrationPlatform ● X‐RallyIntegrationLibrary**
