### PR TITLE
Allow for Pre-Configured HTTP Client and Basic Auth Changes

### DIFF
--- a/src/main/java/com/rallydev/rest/RallyRestApi.java
+++ b/src/main/java/com/rallydev/rest/RallyRestApi.java
@@ -1,15 +1,25 @@
 package com.rallydev.rest;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+
 import com.google.gson.JsonArray;
 import com.rallydev.rest.client.ApiKeyClient;
 import com.rallydev.rest.client.BasicAuthClient;
 import com.rallydev.rest.client.HttpClient;
-import com.rallydev.rest.request.*;
-import com.rallydev.rest.response.*;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.net.URI;
+import com.rallydev.rest.request.CollectionUpdateRequest;
+import com.rallydev.rest.request.CreateRequest;
+import com.rallydev.rest.request.DeleteRequest;
+import com.rallydev.rest.request.GetRequest;
+import com.rallydev.rest.request.QueryRequest;
+import com.rallydev.rest.request.UpdateRequest;
+import com.rallydev.rest.response.CollectionUpdateResponse;
+import com.rallydev.rest.response.CreateResponse;
+import com.rallydev.rest.response.DeleteResponse;
+import com.rallydev.rest.response.GetResponse;
+import com.rallydev.rest.response.QueryResponse;
+import com.rallydev.rest.response.UpdateResponse;
 
 /**
  * <p>The main interface to the Rest API.</p>
@@ -30,6 +40,19 @@ public class RallyRestApi implements Closeable {
     public RallyRestApi(URI server, String userName, String password) {
         this(new BasicAuthClient(server, userName, password));
     }
+    
+    /**
+     * Creates a new instance for the specified server using the specified credentials.
+     *
+     * @param server   The server to connect to, e.g. {@code new URI("https://rally1.rallydev.com")}
+     * @param userName The username to be used for authentication.
+     * @param password The password to be used for authentication.
+     * @param httpClient The pre-configured httpClient.
+     * @deprecated Use the api key constructor instead.
+     */
+    public RallyRestApi(URI server, String userName, String password, org.apache.http.client.HttpClient httpClient) {
+        this(new BasicAuthClient(server, userName, password, httpClient));
+    }
 
     /**
      * Creates a new instance for the specified server using the specified API Key.
@@ -39,6 +62,17 @@ public class RallyRestApi implements Closeable {
      */
     public RallyRestApi(URI server, String apiKey) {
         this(new ApiKeyClient(server, apiKey));
+    }
+
+    /**
+     * Creates a new instance for the specified server using the specified API Key and a pre-configured httpClient.
+     * 
+     * @param server The server to connect to, e.g. {@code new URI("https://rally1.rallydev.com")}
+     * @param apiKey The API Key to be used for authentication.
+     * @param httpClient The pre-configured httpClient.
+     */
+    public RallyRestApi(URI server, String apiKey, org.apache.http.client.HttpClient httpClient) {
+        this(new ApiKeyClient(server, apiKey, httpClient));
     }
 
     protected RallyRestApi(HttpClient httpClient) {

--- a/src/main/java/com/rallydev/rest/client/ApiKeyClient.java
+++ b/src/main/java/com/rallydev/rest/client/ApiKeyClient.java
@@ -1,9 +1,9 @@
 package com.rallydev.rest.client;
 
-import org.apache.http.client.methods.HttpRequestBase;
-
 import java.io.IOException;
 import java.net.URI;
+
+import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * A HttpClient which authenticates using an API Key.
@@ -20,6 +20,17 @@ public class ApiKeyClient extends HttpClient {
      */
     public ApiKeyClient(URI server, String apiKey) {
         super(server);
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * Construct a new client with a pre-configured HttpClient.
+     * 
+     * @param server the server to connect to
+     * @param apiKey the key to be used for authentication
+     */
+    public ApiKeyClient(URI server, String apiKey, org.apache.http.client.HttpClient httpClient) {
+        super(server, httpClient);
         this.apiKey = apiKey;
     }
 

--- a/src/main/java/com/rallydev/rest/client/HttpClient.java
+++ b/src/main/java/com/rallydev/rest/client/HttpClient.java
@@ -1,23 +1,27 @@
 package com.rallydev.rest.client;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DecompressingHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A HttpClient implementation providing connectivity to Rally.  This class does not
@@ -28,7 +32,7 @@ public class HttpClient extends DefaultHttpClient
 
     protected URI server;
     protected String wsapiVersion = "v2.0";
-    protected DecompressingHttpClient client;
+    protected org.apache.http.client.HttpClient client;
 
     private enum Header {
         Library,
@@ -49,6 +53,17 @@ public class HttpClient extends DefaultHttpClient
     protected HttpClient(URI server) {
         this.server = server;
         client = new DecompressingHttpClient(this);
+    }
+
+    /**
+     * Allow the user to specify a compliant HttpClient
+     * 
+     * @param server The URI of the remote server
+     * @param client A pre-configured HttpClient implementation
+     */
+    public HttpClient(URI server, org.apache.http.client.HttpClient client) {
+        this.server = server;
+        this.client = client;
     }
 
     /**

--- a/src/test/java/com/rallydev/rest/client/ApiKeyClientTest.java
+++ b/src/test/java/com/rallydev/rest/client/ApiKeyClientTest.java
@@ -1,18 +1,23 @@
 package com.rallydev.rest.client;
 
-import com.rallydev.rest.matchers.HttpRequestHeaderMatcher;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.*;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.rallydev.rest.matchers.HttpRequestHeaderMatcher;
 
 public class ApiKeyClientTest {
 
@@ -31,10 +36,25 @@ public class ApiKeyClientTest {
         Assert.assertEquals(client.getServer(), server);
     }
 
+    @SuppressWarnings("resource")
+    @Test
+    public void shouldIntializePreConfiguredClient() throws URISyntaxException {
+        HttpClient mockClient = mock(HttpClient.class);
+        ApiKeyClient client = new ApiKeyClient(new URI(server), apiKey, mockClient);
+        Assert.assertEquals(client.getServer(), server);
+    }
+
     @Test
     public void shouldIncludeApiKeyOnRequest() throws Exception {
         doReturn("").when(client).executeRequest(any(HttpRequestBase.class));
         client.doRequest(new HttpGet());
         verify(client).doRequest(argThat(new HttpRequestHeaderMatcher("zsessionid", apiKey)));
+    }
+
+    @Test
+    public void shouldReturnPreConfiguredClient() throws Exception {
+        DefaultHttpClient mockClient = mock(DefaultHttpClient.class);
+        ApiKeyClient spiedClient = spy(new ApiKeyClient(new URI(server), apiKey, mockClient));
+        Assert.assertEquals(spiedClient.client, mockClient);
     }
 }


### PR DESCRIPTION
This change allows a user to provide a pre-configured HTTP Client to be
used for managing connections to CA Agile Central.

The is primarily useful in long running processes, such as code running
inside of a container.

This providers several benefits :
1. Connection reuse and simplified resource handling (can centralize
connection creation and clean up only on shutdown rather than needing to
explicitly close connections)
2. Connection Pooling Options
3. Client SSL Configuration Options

--

Updated Basic Auth Client to always provide Basic Auth Crendetials to
avoid blind duplicate calls.  Since we know that all requests require
authorization, we should always send the credentials.